### PR TITLE
add shell_version 43 into metadata.json

### DIFF
--- a/always-indicator@martin.zurowietz.de/metadata.json
+++ b/always-indicator@martin.zurowietz.de/metadata.json
@@ -5,7 +5,8 @@
   "shell-version": [
     "40",
     "41",
-    "42"
+    "42",
+    "43"
   ],
   "url": "https://github.com/mzur/gnome-shell-always-indicator",
   "uuid": "always-indicator@martin.zurowietz.de",


### PR DESCRIPTION
Add shell 43 version support in metadata.json to use this extension against gnome 43. 

issue: https://github.com/mzur/gnome-shell-always-indicator/issues/13

@mzur 