### PR TITLE
Add GNOME 47 support

### DIFF
--- a/always-indicator@martin.zurowietz.de/metadata.json
+++ b/always-indicator@martin.zurowietz.de/metadata.json
@@ -4,7 +4,8 @@
   "name": "Always Indicator",
   "shell-version": [
     "45",
-    "46"
+    "46",
+    "47"
   ],
   "url": "https://github.com/mzur/gnome-shell-always-indicator",
   "uuid": "always-indicator@martin.zurowietz.de",


### PR DESCRIPTION
I tested it inside VM, extension works without issues.

![image](https://github.com/user-attachments/assets/2fbef180-64e5-41fa-bd1c-5db1a6c9da53)

GNOME 47 will be released on 14th September.